### PR TITLE
favorites page, with breadcrumbs

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Login />} />
           <Route path="/home/*?" element={<Home />} />
-          <Route path="/favorites" element={<Favorites />} />
+          <Route path="/favorites/*?" element={<Favorites />} />
           <Route path="/shared" element={<Shared />} />
           <Route path="/trash" element={<Trash />} />
           <Route path="/register" element={<Register />} />

--- a/client/src/pages/Favorites.tsx
+++ b/client/src/pages/Favorites.tsx
@@ -3,11 +3,102 @@ import SearchBar from '../components/SearchBar';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { typography } from '../Styles';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { FolderProps } from '../components/Folder';
+import axios from 'axios';
+import FileContainer from '../components/FileContainer';
+import FolderContainer from '../components/FolderContainer';
+import { useUser } from '../context/UserContext';
 
 const Favorites = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const userContext = useUser();
+
+  const folderPath = location.pathname
+    .replace('/favorites', '')
+    .split('/')
+    .filter(Boolean);
+  const currentFolderId = folderPath.length
+    ? folderPath[folderPath.length - 1]
+    : null;
+
+  const [folders, setFolders] = useState<FolderProps[]>([]);
+  const [files, setFiles] = useState([]);
+  const [folderNames, setFolderNames] = useState<{ [key: string]: string }>({});
+  const itemsPerPage = 5;
+
+  useEffect(() => {
+    fetchData(currentFolderId);
+    fetchFolderNames(folderPath);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentFolderId]);
+
+  const fetchData = async (folderId: string | null) => {
+    try {
+      let foldersRes, filesRes;
+
+      if (!folderId) {
+        console.log('in favorites page');
+        [foldersRes, filesRes] = await Promise.all([
+          axios.get('http://localhost:5001/api/folder/favorites', {
+            withCredentials: true,
+          }),
+          axios.get('http://localhost:5001/api/file/favorites', {
+            withCredentials: true,
+          }),
+        ]);
+      } else {
+        console.log('in nested favorites page');
+        [foldersRes, filesRes] = await Promise.all([
+          axios.post(
+            'http://localhost:5001/api/folder/parent',
+            { folderId },
+            { withCredentials: true },
+          ),
+          axios.post(
+            'http://localhost:5001/api/file/folder',
+            { folderId },
+            { withCredentials: true },
+          ),
+        ]);
+      }
+
+      setFolders(foldersRes.data);
+      setFiles(filesRes.data);
+    } catch (error) {
+      console.error('Error fetching data:', error);
+    }
+  };
+
+  const fetchFolderNames = async (folderIds: string[]) => {
+    try {
+      const nameRequests = folderIds.map((id) =>
+        axios.get(`http://localhost:5001/api/folder/foldername/${id}`),
+      );
+      const nameResponses = await Promise.all(nameRequests);
+      const newFolderNames: { [key: string]: string } = {};
+      folderIds.forEach((id, index) => {
+        newFolderNames[id] = nameResponses[index].data;
+      });
+      setFolderNames((prevNames) => ({ ...prevNames, ...newFolderNames }));
+    } catch (error) {
+      console.error('Error fetching folder names:', error);
+    }
+  };
+
+  const handleFolderClick = (folder: FolderProps) => {
+    navigate(`/favorites/${[...folderPath, folder.id].join('/')}`);
+  };
+
+  const handleBreadcrumbClick = (index: number) => {
+    navigate(`/favorites/${folderPath.slice(0, index + 1).join('/')}`);
+  };
+
   return (
     <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
-      {/* Sticky Header Section with Title and Search Bar */}
+      {/* Sticky Header Section with Title, Breadcrumb, and Search Bar */}
       <Box
         sx={{
           position: 'sticky',
@@ -26,9 +117,9 @@ const Favorites = () => {
           variant="h1"
           sx={{
             fontWeight: 'bold',
-            fontFamily: typography.fontFamily, 
-            fontSize: typography.fontSize.extraLarge, 
-            color: '#161C94', 
+            fontFamily: typography.fontFamily,
+            fontSize: typography.fontSize.extraLarge,
+            color: '#161C94',
             marginLeft: '10px',
             paddingTop: '25px',
             paddingBottom: '30px',
@@ -39,25 +130,58 @@ const Favorites = () => {
 
         {/* Search Bar */}
         <SearchBar location="Favorites" />
+
+        {/* Breadcrumb Navigation */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            fontSize: '14px',
+          }}
+        >
+          {['Favorites', ...folderPath].map((crumb, index) => (
+            <span
+              key={index}
+              onClick={() => handleBreadcrumbClick(index - 1)}
+              style={{
+                cursor: 'pointer',
+                color: '#161C94',
+                fontWeight: 'bold',
+                marginLeft: '10px',
+              }}
+            >
+              {index === 0 ? 'Favorites' : folderNames[crumb] || ''}
+              {index < folderPath.length ? ' / ' : ''}
+            </span>
+          ))}
+        </Box>
       </Box>
 
       {/* Scrollable Content */}
       <Box sx={{ flexGrow: 1, overflowY: 'auto', padding: '20px' }}>
-        {/* Folders Section */}
-        <Box sx={{ marginLeft: '10px' }}>
-          <Typography variant="h2" sx={{ fontSize: typography.fontSize.extraLarge, fontWeight: 'bold' }}>
-            Folders
-          </Typography>
-        </Box>
+        <div style={{ marginLeft: '10px' }}>
+          <FolderContainer
+            folders={folders}
+            onFolderClick={handleFolderClick}
+            currentFolderId={currentFolderId}
+            refreshFolders={fetchData}
+            itemsPerPage={itemsPerPage}
+            username={userContext?.username || ''}
+          />
+        </div>
 
-        <Divider sx={{ margin: '20px 0' }} />
+        <Divider style={{ margin: '20px 0' }} />
 
         {/* Files Section */}
-        <Box sx={{ marginLeft: '10px' }}>
-          <Typography variant="h2" sx={{ fontSize: typography.fontSize.extraLarge, fontWeight: 'bold' }}>
-            Files
-          </Typography>
-        </Box>
+        <div style={{ marginLeft: '10px' }}>
+          <FileContainer
+            files={files}
+            currentFolderId={currentFolderId}
+            refreshFiles={fetchData}
+            username={userContext?.username || ''}
+          />
+        </div>
       </Box>
     </Box>
   );

--- a/server/src/routes/files/files.ts
+++ b/server/src/routes/files/files.ts
@@ -75,33 +75,33 @@ fileRouter.post(
 );
 
 /**
- * GET /api/files/favorites/:ownerId
+ * GET /api/files/favorites/
  * Route to get favorited files owned by a certain user (ownerId).
  * This is protected by authorize
  */
 
-fileRouter.get('/favorites/:ownerId', authorize, async (req, res) => {
-  try {
-    const { ownerId } = req.params;
+fileRouter.get(
+  '/favorites',
+  authorize,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      const userId = req.user.userId;
 
-    // ******** CHECK THIS OUT If we only want to let users get their own files
-    if ((req as any).user.userId !== ownerId) {
-      return res.status(403).json({
-        message: 'Forbidden: You can only access your own favorited files.',
-      });
+      const favoritedFiles = await FileModel.getAllByOwnerAndColumn(
+        userId,
+        'isFavorited',
+        true,
+      );
+      return res.json(favoritedFiles);
+    } catch (error) {
+      console.error('Error getting files by owner:', error);
+      return res.status(500).json({ error: 'Internal Server Error' });
     }
-
-    const favoritedFiles = await FileModel.getAllByOwnerAndColumn(
-      ownerId,
-      'isFavorited',
-      true,
-    );
-    return res.json(favoritedFiles);
-  } catch (error) {
-    console.error('Error getting files by owner:', error);
-    return res.status(500).json({ error: 'Internal Server Error' });
-  }
-});
+  },
+);
 
 /**
  * POST /api/files/upload


### PR DESCRIPTION
(nested or non-nested) files and folders will show on the front page of Favorites.tsx 

working favorites page (shows ALL favorited folders/files by user on the favorites landing page, HOWEVER, if u navigate in, files/folders may not be guaranteed to be favorited... need to discuss whether to breadcrumb from favorites or from home; currently its breadcrumbing from favorites... im pretty sure Google Drive sends u breadcrumbing from home BUT we need to then create an api for finding all path for a given folderId back to root (all parents) since we cannot store parent path in the url unlike Home.tsx...) 

@gyuheon0h 

⚠️  currently breadcrumbing from favorites... therefore does not guarantee nested files are also favorited, only top layer 

⚠️  since we are eventually adding a search bar, breadcrumbing from home is preferred 

⚠️  will be refactored after we extend to all non-owners to favorite files/folders so i didnt go too deep

⚠️  should a file be unfavorited if its deleted?