### PR TITLE
updated base model, permission model, and routes

### DIFF
--- a/server/src/db_models/PermissionModel.ts
+++ b/server/src/db_models/PermissionModel.ts
@@ -32,6 +32,38 @@ class PermissionModel extends BaseModel<Permission> {
     }
   }
 
+  // Get permission rows where fileId is a File based on userId
+  async getFilesByUserId(userId: string): Promise<Permission[]> {
+    try {
+      return await this.getAllByJoin(
+        'File',
+        '"Permission"."fileId" = "File"."id"',
+        'userId',
+        userId,
+        true,
+      );
+    } catch (error) {
+      console.error('Error retrieving file permissions by userId:', error);
+      throw error;
+    }
+  }
+
+  // Get permission rows where folderId is a Folder based on userId
+  async getFoldersByUserId(userId: string): Promise<Permission[]> {
+    try {
+      return await this.getAllByJoin(
+        'Folder',
+        '"Permission"."fileId" = "Folder"."id"',
+        'userId',
+        userId,
+        true,
+      );
+    } catch (error) {
+      console.error('Error retrieving folder permissions by userId:', error);
+      throw error;
+    }
+  }
+
   // Create a new permission
   async createPermission(data: Partial<Permission>): Promise<Permission> {
     try {
@@ -43,7 +75,10 @@ class PermissionModel extends BaseModel<Permission> {
   }
 
   // Update an existing permission
-  async updatePermission(id: string, data: Partial<Permission>): Promise<Permission | null> {
+  async updatePermission(
+    id: string,
+    data: Partial<Permission>,
+  ): Promise<Permission | null> {
     try {
       return await this.update(id, data);
     } catch (error) {

--- a/server/src/db_models/PermissionModel.ts
+++ b/server/src/db_models/PermissionModel.ts
@@ -32,6 +32,21 @@ class PermissionModel extends BaseModel<Permission> {
     }
   }
 
+  /**
+   * Get a permission by fileId and userId (excluding soft-deleted).
+   */
+  async getPermissionByFileAndUser(
+    fileId: string,
+    userId: string,
+  ): Promise<Permission | null> {
+    try {
+      return await this.getOneByMultipleColumns({ fileId, userId }, false);
+    } catch (error) {
+      console.error('Error getting permission by fileId/userId:', error);
+      throw error;
+    }
+  }
+
   // Get permission rows where fileId is a File based on userId
   async getFilesByUserId(userId: string): Promise<Permission[]> {
     try {

--- a/server/src/db_models/baseModel.ts
+++ b/server/src/db_models/baseModel.ts
@@ -140,6 +140,26 @@ class BaseModel<T> {
     );
     return result.rows as T[];
   }
+
+  protected async getAllByJoin<K extends keyof T>(
+    joinTable: string,
+    joinOn: string,
+    column: K,
+    value: T[K],
+    checkJoinTableDeletedAt = true,
+  ): Promise<T[]> {
+    const query = `
+      SELECT baseTable.*
+      FROM "${this.table}" baseTable
+      JOIN "${joinTable}" joinTbl ON ${joinOn}
+      WHERE baseTable."${String(column)}" = $1
+        AND baseTable."deletedAt" IS NULL
+        ${checkJoinTableDeletedAt ? `AND joinTbl."deletedAt" IS NULL` : ''}
+    `;
+
+    const result = await pool.query(query, [value]);
+    return result.rows as T[];
+  }
 }
 
 export default BaseModel;

--- a/server/src/routes/files/files.ts
+++ b/server/src/routes/files/files.ts
@@ -369,7 +369,7 @@ fileRouter.put(
 
 /**
  * DELETE /api/files/:fileId/permissions/:userId
- * Removes the permission for a particular user on a file (i.e., unshare).
+ * Removes the permission for a particular user on a file
  */
 fileRouter.delete(
   '/:fileId/permissions/:userId',

--- a/server/src/routes/files/files.ts
+++ b/server/src/routes/files/files.ts
@@ -266,16 +266,158 @@ fileRouter.patch('/rename/:fileId', authorize, async (req, res) => {
   }
 });
 
+/**
+ * GETS all permissions pertaining to the userId
+ */
 fileRouter.get('/shared', authorize, async (req: AuthenticatedRequest, res) => {
   try {
-    const userId = (req as any).user.userId;
-    const sharedWithUser = await PermissionModel.getFilesByUserId(userId);
+    const currentUserId = (req as any).user.userId;
+    if (!currentUserId) {
+      return res.status(401).json({ error: 'Not authenticated' });
+    }
+
+    const sharedWithUser =
+      await PermissionModel.getFilesByUserId(currentUserId);
     return res.json(sharedWithUser);
   } catch (error) {
     console.error('Error getting deleted files:', error);
     return res.status(500).json({ error: 'Internal Server Error' });
   }
 });
+
+/**
+ * GETS all permissions pertaining to the fileId
+ */
+fileRouter.get(
+  '/:fileId/permissions',
+  authorize,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const currentUserId = (req as any).user.userId;
+      if (!currentUserId) {
+        return res.status(401).json({ error: 'Not authenticated' });
+      }
+
+      const { fileId } = req.params;
+      const sharedWith = await PermissionModel.getPermissionsByFileId(fileId);
+      return res.json(sharedWith);
+    } catch (error) {
+      console.error('Error getting deleted files:', error);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  },
+);
+
+/**
+ * PUT /api/files/:fileId/permissions/:userId
+ * Updates or creates a permission (cannot change to 'owner' if not already owner)
+ */
+fileRouter.put(
+  '/:fileId/permissions/:userId',
+  authorize,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const currentUserId = (req as any).user.userId;
+      if (!currentUserId) {
+        return res.status(401).json({ error: 'Not authenticated' });
+      }
+
+      const { fileId, userId } = req.params;
+      const { role } = req.body;
+
+      // fetch file
+      const file = await FileModel.getById(fileId);
+      if (!file) return res.status(404).json({ error: 'File not found.' });
+
+      // check owner
+      if (file.owner !== currentUserId) {
+        return res.status(403).json({ error: 'Not allowed.' });
+      }
+
+      // try to find existing permission
+      const existingPerm = await PermissionModel.getPermissionByFileAndUser(
+        fileId,
+        userId,
+      );
+
+      if (existingPerm) {
+        // update
+        const updated = await PermissionModel.updatePermission(
+          existingPerm.id,
+          {
+            role,
+          },
+        );
+        return updated
+          ? res.json(updated)
+          : res.status(500).json({ error: 'Could not update permission.' });
+      } else {
+        // create
+        const created = await PermissionModel.createPermission({
+          fileId,
+          userId,
+          role,
+        });
+        return res.status(201).json(created);
+      }
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  },
+);
+
+/**
+ * DELETE /api/files/:fileId/permissions/:userId
+ * Removes the permission for a particular user on a file (i.e., unshare).
+ */
+fileRouter.delete(
+  '/:fileId/permissions/:userId',
+  authorize,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      const currentUserId = req.user?.userId;
+      if (!currentUserId) {
+        return res.status(401).json({ error: 'Not authenticated' });
+      }
+
+      const { fileId, userId } = req.params;
+
+      // fetch file
+      const file = await FileModel.getById(fileId);
+      if (!file) {
+        return res.status(404).json({ error: 'File not found' });
+      }
+
+      // check owner
+      if (file.owner !== currentUserId) {
+        return res
+          .status(403)
+          .json({ error: 'You do not have permission to modify this file.' });
+      }
+
+      // try to find existing permission with (fileId, userId)
+      const existingPerm = await PermissionModel.getPermissionByFileAndUser(
+        fileId,
+        userId,
+      );
+
+      if (!existingPerm) {
+        return res.status(404).json({
+          error: 'No permission entry found for this user/file pair.',
+        });
+      }
+
+      // hard delete from permission
+      await PermissionModel.hardDeletePermission(existingPerm.id);
+
+      return res.sendStatus(204);
+    } catch (error) {
+      console.error('Error removing permission:', error);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  },
+);
 
 fileRouter.get('/trash', authorize, async (req: AuthenticatedRequest, res) => {
   try {


### PR DESCRIPTION
added `getAllByJoin()` in the baseModel to determine if a given `fileId` in the `Permissions` table is a `File` or `Folder`

created the two endpoints for fetching data on the `Shared With` Page

`localhost:5001/api/files/shared`: AuthenticatedRequest -- returns all files shared with the user.id

`localhost:5001/api/folders/shared`: AuthenticatedRequest -- returns all folders shared with the user.id