### PR TITLE
upgrade favorites to allow users to favorite any shared files/folders

### DIFF
--- a/client/src/components/File.tsx
+++ b/client/src/components/File.tsx
@@ -27,6 +27,7 @@ import {
   getUsernameById,
   downloadFile,
   getBlobGcskey,
+  getIsFavoritedByFileId,
 } from '../utils/helperRequests';
 import PermissionDialog from './PermissionsDialog';
 import FavoriteIcon from '@mui/icons-material/Favorite';
@@ -88,6 +89,7 @@ const FileComponent = (props: FileComponentProps) => {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const fileCache = useRef(new Map<string, string>());
+  const [isFavorited, setIsFavorited] = useState(false);
 
   // For the image viewer
   const [isFileViewerOpen, setIsFileViewerOpen] = useState(false);
@@ -128,6 +130,21 @@ const FileComponent = (props: FileComponentProps) => {
 
     fetchModifiedByName();
   }, [props.file.lastModifiedBy]);
+
+
+  useEffect(() => {
+    const fetchIsFavorited = async () => {
+      try {
+        const isFavorited = await getIsFavoritedByFileId(props.file.id); 
+        setIsFavorited(isFavorited);
+      } catch (error) {
+        console.error("Error fetching isFavorited for file", error);
+        setError("Error fetching isFavorited for file");
+      }
+    };
+
+    fetchIsFavorited();
+  }, [props.file.id]);
 
   const open = Boolean(anchorEl);
 
@@ -203,19 +220,14 @@ const FileComponent = (props: FileComponentProps) => {
     if (props.page === 'trash') {
       alert('Restore the file to update it!');
     } else {
-      await handleFavoriteFile(props.file.id, props.file.owner);
+      await handleFavoriteFile(props.file.id);
+      setIsFavorited(!isFavorited); // toggle state locally
     }
     props.refreshFiles(props.file.parentFolder);
   };
 
-  const handleFavoriteFile = async (fileId: string, owner: string) => {
-    // const ownerUsername = await getUsernameById(owner);
-
-    // TODO: see comment in FolderComponent
-    // if (ownerUsername !== username) {
-    //   alert('You do not have permission to favorite this file.');
-    //   return;
-    // }
+  const handleFavoriteFile = async (fileId: string) => {
+    // Note: still calling the patch through the file endpoint, but it's using the permission model
     try {
       await axios.patch(
         `http://localhost:5001/api/file/favorite/${fileId}`,
@@ -374,10 +386,10 @@ const FileComponent = (props: FileComponentProps) => {
         <IconButton
           onClick={handleFavoriteFileClick}
           sx={{
-            color: props.file.isFavorited ? '#FF6347' : colors.darkBlue,
+            color: isFavorited ? '#FF6347' : colors.darkBlue,
           }}
         >
-          {props.file.isFavorited ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+          {isFavorited ? <FavoriteIcon /> : <FavoriteBorderIcon />}
         </IconButton>
 
         <IconButton

--- a/client/src/components/Page.tsx
+++ b/client/src/components/Page.tsx
@@ -114,7 +114,8 @@ const PageComponent: React.FC<PageComponentProps> = ({
       if (page === 'favorites') {
         if (!folderId) {
           filesRes = await axios.get(
-            'http://localhost:5001/api/file/favorites',
+            // 'http://localhost:5001/api/file/favorites',
+            `http://localhost:5001/api/user/${userId}/favorites/file`,
             {
               withCredentials: true,
             },
@@ -185,7 +186,8 @@ const PageComponent: React.FC<PageComponentProps> = ({
       if (page === 'favorites') {
         if (!folderId) {
           folderRes = await axios.get(
-            'http://localhost:5001/api/folder/favorites',
+            // 'http://localhost:5001/api/folder/favorites',
+            `http://localhost:5001/api/user/${userId}/favorites/folder`,
             {
               withCredentials: true,
             },

--- a/client/src/interfaces/File.ts
+++ b/client/src/interfaces/File.ts
@@ -8,5 +8,4 @@ export interface File {
   parentFolder: string | null;
   gcsKey: string;
   fileType: string;
-  isFavorited: boolean;
 }

--- a/client/src/interfaces/Folder.ts
+++ b/client/src/interfaces/Folder.ts
@@ -4,5 +4,4 @@ export interface Folder {
   owner: string;
   createdAt: Date;
   parentFolder: string | null;
-  isFavorited: boolean;
 }

--- a/client/src/interfaces/Permission.ts
+++ b/client/src/interfaces/Permission.ts
@@ -3,5 +3,6 @@ export interface Permission {
   fileId: string; // or folderId if it's a folder
   userId: string;
   role: 'owner' | 'editor' | 'viewer';
+  isFavorited: boolean;
   deletedAt: Date | null;
 }

--- a/client/src/interfaces/Permission.ts
+++ b/client/src/interfaces/Permission.ts
@@ -3,6 +3,6 @@ export interface Permission {
   fileId: string; // or folderId if it's a folder
   userId: string;
   role: 'owner' | 'editor' | 'viewer';
-  isFavorited: boolean;
   deletedAt: Date | null;
+  isFavorited: boolean;
 }

--- a/client/src/utils/helperRequests.ts
+++ b/client/src/utils/helperRequests.ts
@@ -33,6 +33,19 @@ export async function getUsernameById(id: string): Promise<string> {
   }
 }
 
+export async function getIsFavoritedByFileId(fileId: string): Promise<boolean> {
+  try {
+    const response = await axios.get(`http://localhost:5001/api/user/permissions/${fileId}`, 
+      { withCredentials: true }
+    );
+     
+    return response.data?.isFavorited || false;
+  } catch (error) {
+    console.error("Error fetching isFavorited status: ", error);
+    return false;
+  }
+}
+
 export async function downloadFile(
   fileId: string,
   fileName: string,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,4 +1,4 @@
-import express, { Application, Request, Response } from 'express';
+ import express, { Application, Request, Response } from 'express';
 import cors from 'cors';
 import apiRoutes from './routes/api'; // Collects all API routes
 import { query } from './db_models/db';

--- a/server/src/db_models/FileModel.ts
+++ b/server/src/db_models/FileModel.ts
@@ -10,7 +10,6 @@ interface File {
   parentFolder: string | null;
   gcsKey: string;
   fileType: string;
-  isFavorited: boolean;
 }
 
 class FileModel extends BaseModel<File> {

--- a/server/src/db_models/FolderModel.ts
+++ b/server/src/db_models/FolderModel.ts
@@ -6,7 +6,6 @@ interface Folder {
   owner: string;
   createdAt: Date;
   parentFolder: string | null;
-  isFavorited: boolean;
 }
 
 class FolderModel extends BaseModel<Folder> {
@@ -64,7 +63,7 @@ class FolderModel extends BaseModel<Folder> {
     return folder?.name || '';
   }
 
-  // Update folder metadata (e.g., name, isFavorited)
+  // Update folder metadata (e.g., name)
   async updateFolderMetadata(
     id: string,
     updatedData: Partial<Folder>,

--- a/server/src/db_models/PermissionModel.ts
+++ b/server/src/db_models/PermissionModel.ts
@@ -2,9 +2,10 @@ import BaseModel from './baseModel';
 
 interface Permission {
   id: string;
-  fileId: string;
+  fileId: string; // includes folders
   userId: string;
   role: 'owner' | 'editor' | 'viewer';
+  isFavorited: boolean;
   deletedAt: Date | null;
 }
 
@@ -13,7 +14,7 @@ class PermissionModel extends BaseModel<Permission> {
     super('Permission');
   }
 
-  // Get all permissions for a specific file
+  // Get all permissions for a specific file/folder
   async getPermissionsByFileId(fileId: string): Promise<Permission[]> {
     try {
       return await this.getAllByColumn('fileId', fileId);

--- a/server/src/routes/files/files.ts
+++ b/server/src/routes/files/files.ts
@@ -82,34 +82,6 @@ fileRouter.post(
   },
 );
 
-/**
- * GET /api/files/favorites/
- * Route to get favorited files owned by a certain user (ownerId).
- * This is protected by authorize
- */
-
-fileRouter.get(
-  '/favorites',
-  authorize,
-  async (req: AuthenticatedRequest, res) => {
-    try {
-      if (!req.user) {
-        return res.status(401).json({ error: 'Unauthorized' });
-      }
-      const userId = req.user.userId;
-
-      const favoritedFiles = await FileModel.getAllByOwnerAndColumn(
-        userId,
-        'isFavorited',
-        true,
-      );
-      return res.json(favoritedFiles);
-    } catch (error) {
-      console.error('Error getting files by owner:', error);
-      return res.status(500).json({ error: 'Internal Server Error' });
-    }
-  },
-);
 
 /**
  * POST /api/files/upload
@@ -151,7 +123,6 @@ fileRouter.post(
         parentFolder: parentFolder || null, // Allow null for root files
         gcsKey: gcsFilePath,
         fileType: mimetype,
-        isFavorited: false,
       });
 
       return res
@@ -232,25 +203,19 @@ fileRouter.patch('/favorite/:fileId', authorize, async (req, res) => {
   try {
     const userId = (req as any).user.userId;
     const { fileId } = req.params;
-    const file = await FileModel.getById(fileId);
+    const permission = await PermissionModel.getPermissionByFileAndUser(fileId, userId);
 
-    if (!file) {
+    if (!permission) {
       return res.status(404).json({ message: 'File not found' });
-    }
+    };
 
-    if (userId != file.owner) {
-      return res.status(403).json({
-        message: 'Unauthorized: User cannot favorite files they do not own',
-      });
-    }
-
-    const fileMetadata = await FileModel.updateFileMetadata(fileId, {
-      isFavorited: !file.isFavorited,
+    const permissionMetadata = await PermissionModel.updatePermission(permission.id, {
+      isFavorited: !permission.isFavorited,
     });
 
     return res.status(200).json({
       message: 'File favorited successfully',
-      file: fileMetadata,
+      file: permissionMetadata,
     });
   } catch (error) {
     console.error('File favorite error:', error);

--- a/server/src/routes/folders/folders.ts
+++ b/server/src/routes/folders/folders.ts
@@ -71,6 +71,12 @@ folderRouter.post(
         parentFolder: parentFolder || null,
       });
 
+      await PermissionModel.createPermission({
+        fileId: newFolder.id,
+        userId: owner,
+        role: 'owner',
+      });
+
       return res.status(201).json(newFolder);
     } catch (error) {
       console.error('Error creating folder:', error);
@@ -95,13 +101,17 @@ folderRouter.get('/foldername/:folderId', async (req, res) => {
 });
 
 /**
- * PATCH /api/files/favorite/:folderId
+ * PATCH /api/folder/favorite/:folderId
  * Route to favorite/unfavorite a folder
  */
 folderRouter.patch('/favorite/:folderId', authorize, async (req, res) => {
   try {
     const userId = (req as any).user.userId;
     const { folderId } = req.params;
+
+    
+    // TODO: im thinking this is because we don't create a permission for yourself
+
     const permission = await PermissionModel.getPermissionByFileAndUser(folderId, userId);
 
     if (!permission) {

--- a/server/src/routes/folders/folders.ts
+++ b/server/src/routes/folders/folders.ts
@@ -69,7 +69,6 @@ folderRouter.post(
         owner,
         createdAt: new Date(),
         parentFolder: parentFolder || null,
-        isFavorited: false,
       });
 
       return res.status(201).json(newFolder);
@@ -96,61 +95,26 @@ folderRouter.get('/foldername/:folderId', async (req, res) => {
 });
 
 /**
- * GET /api/files/favorites/:ownerId
- * Route to get favorited files owned by a certain user (ownerId).
- * This is protected by authorize
- */
-
-folderRouter.get(
-  '/favorites',
-  authorize,
-  async (req: AuthenticatedRequest, res) => {
-    try {
-      if (!req.user) {
-        return res.status(401).json({ error: 'Unauthorized' });
-      }
-      const userId = req.user.userId;
-
-      const favoritedFiles = await FolderModel.getAllByOwnerAndColumn(
-        userId,
-        'isFavorited',
-        true,
-      );
-      return res.json(favoritedFiles);
-    } catch (error) {
-      console.error('Error getting files by owner:', error);
-      return res.status(500).json({ error: 'Internal Server Error' });
-    }
-  },
-);
-
-/**
- * PATCH /api/files/favorite/:fileId
- * Route to favorite a file
+ * PATCH /api/files/favorite/:folderId
+ * Route to favorite/unfavorite a folder
  */
 folderRouter.patch('/favorite/:folderId', authorize, async (req, res) => {
   try {
     const userId = (req as any).user.userId;
     const { folderId } = req.params;
-    const folder = await FolderModel.getById(folderId);
+    const permission = await PermissionModel.getPermissionByFileAndUser(folderId, userId);
 
-    if (!folder) {
+    if (!permission) {
       return res.status(404).json({ message: 'Folder not found' });
     }
 
-    if (userId != folder.owner) {
-      return res.status(403).json({
-        message: 'Unauthorized: User cannot favorite folders they do not own',
-      });
-    }
-
-    const folderMetadata = await FolderModel.updateFolderMetadata(folderId, {
-      isFavorited: !folder.isFavorited,
+    const permissionMetadata = await PermissionModel.updatePermission(permission.id, {
+      isFavorited: !permission.isFavorited,
     });
 
     return res.status(200).json({
       message: 'Folder favorited successfully',
-      folder: folderMetadata,
+      folder: permissionMetadata,
     });
   } catch (error) {
     console.error('Folder favorite error:', error);

--- a/server/src/routes/users/users.ts
+++ b/server/src/routes/users/users.ts
@@ -146,8 +146,8 @@ userRouter.get(
 );
 
 /**
- * GET /api/files/favorites/:ownerId
- * Route to get favorited files owned by a certain user (ownerId).
+ * GET /api/:userId/favorites/folder
+ * Route to get favorited folders (including shared).
  * This is protected by authorize
  */
 
@@ -161,23 +161,54 @@ userRouter.get(
       }
       const userId = req.user.userId;
 
-      const favoritedFolders = await FolderModel.getAllByOwnerAndColumn(
-        userId,
-        'isFavorited',
-        true,
+      const permissions = await PermissionModel.getFoldersByUserId(userId);
+      const favoritedFolders = await Promise.all(
+        permissions.filter(perm => perm.isFavorited === true)
+        .map((perm) => FolderModel.getById(perm.fileId)),
       );
+
       return res.json(favoritedFolders);
     } catch (error) {
-      console.error('Error getting files by owner:', error);
+      console.error('Error getting folders favorited by user:', error);
       return res.status(500).json({ error: 'Internal Server Error' });
     }
   },
 );
 
 /**
- * GET /api/files/favorites/
- * Route to get favorited files owned by a certain user (ownerId).
- * This is protected by authorize
+ * GET /api/user/permissions/:fileId
+ * Route to get the permission for the user for the individual folder or file
+ * (mainly used to access the isFavorited status).
+ * 
+ * Note: you don't need :userId because it's implicitly passed in through the session token,
+ * unless we want it to be consistent with the other routes.
+ */
+
+userRouter.get(
+  "/permissions/:fileId",
+  authorize, 
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      if (!req.user) {
+        return res.status(401).json({error: "Unauthorized"});
+      }
+
+      const userId = req.user.userId;
+      const { fileId } = req.params;
+
+      const permission = await PermissionModel.getPermissionByFileAndUser(fileId, userId);
+      return res.json(permission);
+    } catch (error) {
+      console.error("Error getting permission by user and file: ", error);
+      return res.status(500).json({error: "Internal Service Error"});
+    }
+  },
+);
+
+
+/**
+ * GET /api/:userId/favorites/file
+ * Route to get [userId]'s favorite files (including shared files).
  */
 
 userRouter.get(
@@ -189,15 +220,43 @@ userRouter.get(
         return res.status(401).json({ error: 'Unauthorized' });
       }
       const userId = req.user.userId;
-
-      const favoritedFiles = await FileModel.getAllByOwnerAndColumn(
-        userId,
-        'isFavorited',
-        true,
+      
+      const permissions = await PermissionModel.getFilesByUserId(userId); // TODO: does this include files that you own? how does shared pages work then? does it filter those out?
+      const favoritedFiles = await Promise.all(
+        permissions.filter(perm => perm.isFavorited === true)
+        .map((perm) => FileModel.getById(perm.fileId)),
       );
+
       return res.json(favoritedFiles);
     } catch (error) {
-      console.error('Error getting files by owner:', error);
+      console.error('Error getting files favorited by user:', error);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  },
+);
+
+/**
+ * PATCH /api/userId/favorites/:fileId
+ */
+userRouter.patch(
+  '/:userId/favorites/:fileId',
+  authorize,
+  async (req: AuthenticatedRequest, res) => {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      const userId = req.user.userId;
+      
+      const permissions = await PermissionModel.getFilesByUserId(userId); // TODO: does this include files that you own? how does shared pages work then? does it filter those out?
+      const favoritedFiles = await Promise.all(
+        permissions.filter(perm => perm.isFavorited === true)
+        .map((perm) => FileModel.getById(perm.fileId)),
+      );
+
+      return res.json(favoritedFiles);
+    } catch (error) {
+      console.error('Error getting files favorited by user:', error);
       return res.status(500).json({ error: 'Internal Server Error' });
     }
   },


### PR DESCRIPTION
Previously, users could only favorite files or folders that they owned due to the fact that `isFavorite` state data was stored as a one-off in the `File`/`Folder` table. This new implementation uses the **`Permission` model** (with a 1-1 user to file relationship) so **users can now favorite any file or folders that they have access to.** 
- rerouted favorites page to use the new /user endpoint from [client refactoring PR](https://github.com/gyuheon0h/design-proj/pull/135/files)
- deleted the isFavorited field on `File`/`Folder` + the file/folder specific favorite routes
- updated the database schema in postgres
- added permission record when we create a folder to fix bug; **favorites work for your own files/folders and files/folders shared with you**

related issues: [client refactoring](https://github.com/gyuheon0h/design-proj/pull/135/files), [og favorite](https://github.com/gyuheon0h/design-proj/pull/86)

manually testing rn and favorites work for files/folders other people have shared, but some notes:

- [x] - BUG⚠️ (fixed): favorites don't work for your own files/folders because we don't create a permission record when you're the owner -- future PR? could also keep the isFavorited field and routes for file/folder rn since its owner specific
- also do we want the favorites page to update immediately when you unheart? it looks a little clunky to me but maybe we can adjust the UI/UX to look smoother later

https://github.com/user-attachments/assets/76ce6776-d617-44ae-bab7-5639256da341


