### PR TITLE
Stale cleannnn

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
     "start": "node dist/server.ts",
     "build": "tsc",
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
-    "watch": "tsc --watch"
+    "watch": "tsc --watch",
+    "recordClean": "ts-node src/cron/recordClean.ts"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.15.0",

--- a/server/src/cron/recordClean.ts
+++ b/server/src/cron/recordClean.ts
@@ -1,0 +1,63 @@
+import pool from '../db_models/db';
+import { File } from '../db_models/FileModel';
+import StorageService from '../storage';
+
+async function cleanStaleFiles() {
+  const deleteQuery = `
+        DELETE FROM "File" 
+        WHERE "deletedAt" IS NOT NULL and 
+        "deletedAt" < NOW() - INTERVAL '30 days'
+        RETURNING *`;
+
+  try {
+    const result = await pool.query(deleteQuery);
+    console.log(
+      `${new Date()}: Deleted ${result.rowCount} records that were soft deleted over 30 days ago.`,
+    );
+
+    const deletedFileRows: File[] = result.rows;
+
+    if (deletedFileRows.length > 0) {
+      for (const row of deletedFileRows) {
+        const gcsKey = row.gcsKey;
+        console.log(`Deleting file at path: ${gcsKey}`);
+        await StorageService.deleteFile(gcsKey);
+      }
+    }
+  } catch (error) {
+    console.error(`${new Date()}: Error deleting file records:`, error);
+  }
+}
+
+async function cleanStaleFolders() {
+  const deleteQuery = `
+          DELETE FROM "Folder" 
+          WHERE "deletedAt" IS NOT NULL and 
+          "deletedAt" < NOW() - INTERVAL '30 days'
+          RETURNING *`;
+
+  try {
+    const result = await pool.query(deleteQuery);
+    console.log(
+      `${new Date()}: Deleted ${result.rowCount} records that were soft deleted over 30 days ago.`,
+    );
+  } catch (error) {
+    console.error(`${new Date()}: Error deleting folder records:`, error);
+  }
+}
+
+async function runCleanup() {
+  try {
+    console.log('Starting daily cleanup...');
+    await cleanStaleFiles();
+    await cleanStaleFolders();
+    console.log('Cleanup complete.');
+  } catch (err) {
+    console.error('Error during cleanup:', err);
+  } finally {
+    // Ensure DB pool closes cleanly
+    await pool.end();
+  }
+}
+
+runCleanup();

--- a/server/src/cron/recordClean.ts
+++ b/server/src/cron/recordClean.ts
@@ -55,7 +55,6 @@ async function runCleanup() {
   } catch (err) {
     console.error('Error during cleanup:', err);
   } finally {
-    // Ensure DB pool closes cleanly
     await pool.end();
   }
 }

--- a/server/src/db_models/FileModel.ts
+++ b/server/src/db_models/FileModel.ts
@@ -1,7 +1,7 @@
 import BaseModel from './baseModel';
 import { recursiveDeletePermissions } from './ModelHelpers';
 
-interface File {
+export interface File {
   id: string;
   name: string;
   owner: string;
@@ -15,7 +15,7 @@ interface File {
   deletedAt: Date | null;
 }
 
-class FileModel extends BaseModel<File> {
+export class FileModel extends BaseModel<File> {
   constructor() {
     super('File');
   }


### PR DESCRIPTION
We clean metadata and object store of old records. 

Here is Postgres constraint to make sure deletes are cascaded.

```
CREATE OR REPLACE FUNCTION delete_permissions_for_file()
RETURNS TRIGGER AS $$
BEGIN
    DELETE FROM "Permission" WHERE "fileId" = OLD.id;
    RETURN OLD;
END;
$$ LANGUAGE plpgsql;

CREATE OR REPLACE TRIGGER trg_delete_file_permissions
AFTER DELETE ON "File"
FOR EACH ROW
EXECUTE FUNCTION delete_permissions_for_file();

CREATE OR REPLACE FUNCTION delete_permissions_for_folder()
RETURNS TRIGGER AS $$
BEGIN
    DELETE FROM "Permission" WHERE "fileId" = OLD.id;
    RETURN OLD;
END;
$$ LANGUAGE plpgsql;

CREATE OR REPLACE TRIGGER trg_delete_folder_permissions
AFTER DELETE ON "Folder"
FOR EACH ROW
EXECUTE FUNCTION delete_permissions_for_folder();

```

I implemented as triggers, because our `fileId` in `Permission` table points to both `File` and `Folder`, and pgres doesnt support polymorphic fkeys

The function is ran as a npm command, so that I can set up cron jobs in render
<img width="703" alt="Screenshot 2025-04-17 at 4 10 19 PM" src="https://github.com/user-attachments/assets/7521cc57-f657-4479-b5cc-9a167452190a" />
