### PR TITLE
Hard Delete from Trash Page

### DIFF
--- a/client/src/components/File.tsx
+++ b/client/src/components/File.tsx
@@ -337,15 +337,22 @@ const FileComponent = (props: FileComponentProps) => {
     fetchPermission();
   }, [props.page, props.file.id]);
   const getMenuItems = () => {
+    const menuItems = [];
+
     if (props.page === 'trash') {
-      return (
+      menuItems.push(
         <MenuItem onClick={handleRestoreClick}>
           <RestoreIcon sx={{ fontSize: '20px', marginRight: '9px' }} /> Restore
-        </MenuItem>
+        </MenuItem>,
       );
+      menuItems.push(
+        <MenuItem key="edit" onClick={handleHardDeleteClick}>
+          <DeleteIcon sx={{ fontSize: '20px', marginRight: '9px' }} />
+          Hard Delete
+        </MenuItem>,
+      );
+      return menuItems;
     }
-
-    const menuItems = [];
 
     if (isEditSupported) {
       menuItems.push(
@@ -578,11 +585,15 @@ const FileComponent = (props: FileComponentProps) => {
     await handleRestoreFile(props.file.id, props.file.owner);
     setAnchorEl(null);
 
-    if (props.page === 'trash') {
-      props.refreshFiles(null);
-    } else {
-      props.refreshFiles(props.file.parentFolder);
-    }
+    props.refreshFiles(null);
+  };
+
+  const handleHardDeleteClick = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+    await handleHardDeleteFile(props.file.id, props.file.owner);
+    setAnchorEl(null);
+
+    props.refreshFiles(null);
   };
 
   const handleRestoreFile = async (fileId: string, owner: string) => {
@@ -594,6 +605,17 @@ const FileComponent = (props: FileComponentProps) => {
       );
     } catch (error) {
       console.error('Error restoring file:', error);
+    }
+  };
+
+  const handleHardDeleteFile = async (fileId: string, owner: string) => {
+    try {
+      await axios.delete(
+        `${process.env.REACT_APP_API_BASE_URL}/api/file/${fileId}/hard-delete`,
+        { withCredentials: true },
+      );
+    } catch (error) {
+      console.error('Error hard deleting file:', error);
     }
   };
 

--- a/server/src/db_models/FileModel.ts
+++ b/server/src/db_models/FileModel.ts
@@ -58,6 +58,14 @@ export class FileModel extends BaseModel<File> {
     return await this.softDelete(id);
   }
 
+  async hardDeleteFile(id: string): Promise<boolean> {
+    await recursiveDeletePermissions(id, null);
+
+    const deletedCount = await this.hardDeleteOnCondition('id', id);
+
+    return deletedCount > 0;
+  }
+
   // Restore a file
   async restoreFile(id: string): Promise<boolean> {
     return await this.restore(id);

--- a/server/src/routes/files/files.ts
+++ b/server/src/routes/files/files.ts
@@ -416,6 +416,35 @@ fileRouter.delete(
   },
 );
 
+fileRouter.delete(
+  '/:fileId/hard-delete',
+  authorizeUser,
+  checkPermission('delete'),
+  async (req, res) => {
+    try {
+      const { fileId } = req.params;
+      const file = await FileModel.getById(fileId);
+
+      if (!file) {
+        return res.status(404).json({ message: 'File not found' });
+      }
+
+      // Delete file from GCS
+      await StorageService.deleteFile(file.gcsKey);
+      // this is a little hazardous; this is a hard delete on the GCS;
+      // and should not occur
+
+      // Delete from database
+      await FileModel.hardDeleteFile(fileId);
+
+      return res.json({ message: 'File hard deleted successfully' });
+    } catch (error) {
+      console.error('Error hard deleting file:', error);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  },
+);
+
 /**
  * PATCH /api/files/:fileId/favorite
  * Route to favorite/unfavorite a file


### PR DESCRIPTION
**COMPLETED:**
For `Files` that have been trashed, allow users the menu option of `hard-delete` which removes from the `GCS Storage`, removes and deletes the record from the `Postgres` metadata datastore

**TODO:**
Kinda hard to do the same for `Folders` since you have to recursively go through each child and delete from `GCS Storage`... I'm not confident in doing it ngmi 